### PR TITLE
Better lat lon

### DIFF
--- a/nucos.js
+++ b/nucos.js
@@ -32,7 +32,7 @@
         str = str.replace("east", "e");
         str = str.replace("west", "w");
 
-        // console.log("working with string:");
+        // console.log("working with string:", str);
 
         // change W and S to a negative value
         negative = str.endsWith("w") || str.endsWith("s") ? -1 : 1;
@@ -42,33 +42,56 @@
         // find the parts
         var decimalReg = new RegExp(/[\d.]+/g);
         var numbers = str.match(decimalReg);
-        var deg = 0; min = 0; sec = 0;
+        // console.log("numbers as text", numbers);
 
-        // console.log("numbers:", numbers);
-
+        var deg = 0.0;
+        var min = 0.0;
+        var sec = 0.0;
         if (numbers.length == 1) { // decimal degrees
-            deg = parseFloat(numbers[0]);
+            deg = Number(numbers[0]);
         }
         else if (numbers.length == 2) { // degrees, minutes
-            var deg = parseInt(numbers[0]);
-            var min = parseFloat(numbers[1]);
+            deg = Number(numbers[0]);
+            if (!Number.isInteger(deg)){
+                throw "Value Error: Degrees must be an integer if minutes are there";
+            }
+            min = Number(numbers[1]);
         }
-        else if (numbers.length == 3) { // degrees, minutes, seconds
-            var deg = parseInt(numbers[0]);
-            var min = parseInt(numbers[1]);
-            var sec = parseFloat(numbers[2]);
+        else if (numbers.length === 3) { // degrees, minutes, seconds
+            deg = Number(numbers[0]);
+            if (!Number.isInteger(deg)){
+                throw "Value Error: Degrees must be an integer if minutes are there";
+            }
+            min = Number(numbers[1]);
+            if (!Number.isInteger(min)){
+                throw "Value Error: Minutes must be an integer if seconds are there.";
+            }
+            sec = Number(numbers[2]);
         }
 
         // console.log("deg, min, sec:", deg, min, sec)
 
+        if (deg > 180){
+            throw "Degrees can not be greater than 180"
+        }
+        if ((min > 60) || (sec > 60)){
+            throw "Minutes and seconds can not be greater than 60"
+        }
         var dec = deg + (min / 60) + (sec / 3600);
         // set the sign
-        dec = (Math.sign(dec) == Math.sign(negative)) ? dec : -dec;
-        // to make testing easier?
-        dec = dec.toFixed(8)
-
+        dec = (Math.sign(dec) === Math.sign(negative)) ? dec : -dec;
+        // console.log("final value:", dec)
+        // console.log(Number.isNaN(dec))
+        if (Number.isNaN(dec)){
+            throw "Value Error: invalid numbers";
+        }
+        // This used to return a string, which seems like a bad idea.
+        // but rounding makes tests easier ??
+        dec = Number(dec.toFixed(8))
         return dec;
     };
+
+
 
     /**
      * Method used to calculate the total duration of an in-situ burn

--- a/nucos.js
+++ b/nucos.js
@@ -20,29 +20,52 @@
      * @return The decimal degree amount
     **/
     var sexagesimal2decimal = function(str){
+        /**
+         * This version mirrors what the Python version does
+         * https://github.com/NOAA-ORR-ERD/lat_lon_parser
+        **/
+
         str = str.trim();
-        var decimalReg = new RegExp(/^[\-]?\d*\.\d* ?[WNSE]?$/i);
-        var decData = decimalReg.exec(str);
-        if(decData){
-            return parseFloat(str);
+        str = str.toLowerCase();
+        str = str.replace("north", "n");
+        str = str.replace("south", "s");
+        str = str.replace("east", "e");
+        str = str.replace("west", "w");
+
+        // console.log("working with string:");
+
+        // change W and S to a negative value
+        negative = str.endsWith("w") || str.endsWith("s") ? -1 : 1;
+        // capture minus sign
+        negative = str.startsWith("-") ? -1 : negative;
+
+        // find the parts
+        var decimalReg = new RegExp(/[\d.]+/g);
+        var numbers = str.match(decimalReg);
+        var deg = 0; min = 0; sec = 0;
+
+        // console.log("numbers:", numbers);
+
+        if (numbers.length == 1) { // decimal degrees
+            deg = parseFloat(numbers[0]);
+        }
+        else if (numbers.length == 2) { // degrees, minutes
+            var deg = parseInt(numbers[0]);
+            var min = parseFloat(numbers[1]);
+        }
+        else if (numbers.length == 3) { // degrees, minutes, seconds
+            var deg = parseInt(numbers[0]);
+            var min = parseInt(numbers[1]);
+            var sec = parseFloat(numbers[2]);
         }
 
-        var regEx = new RegExp(sexagesimalPattern.value);
-        var data = regEx.exec(str);
-        var min = 0, sec = 0;
+        // console.log("deg, min, sec:", deg, min, sec)
 
-        if (data){
-            min = parseFloat(data[2]/60);
-            sec = parseFloat(data[4]/3600) || 0;
-        }
-
-        var dec;
-        if (parseFloat(data[1]) > 0){
-            dec = ((parseFloat(data[1]) + min + sec)).toFixed(8);
-        } else {
-            dec = ((parseFloat(data[1]) - min - sec)).toFixed(8);
-        }
-        dec = (['s', 'S', 'w', 'W'].indexOf(data[7]) !== -1) ? parseFloat(-dec) : parseFloat(dec);
+        var dec = deg + (min / 60) + (sec / 3600);
+        // set the sign
+        dec = (Math.sign(dec) == Math.sign(negative)) ? dec : -dec;
+        // to make testing easier?
+        dec = dec.toFixed(8)
 
         return dec;
     };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,11 +1,11 @@
 var assert = require('assert');
 
 describe('nucos', function(){
-    it('should import with amd', function(){
-        var requirejs = require('requirejs');
-        var n_test = requirejs('/../nucos.js');
-        assert.notEqual(n_test, undefined);
-    });
+    // it('should import with amd', function(){
+    //     var requirejs = require('requirejs');
+    //     var n_test = requirejs('/../nucos.js');
+    //     assert.notEqual(n_test, undefined);
+    // });
 
     it('should import with commonjs', function(){
         var n_test = require('../nucos');
@@ -15,6 +15,12 @@ describe('nucos', function(){
 
 var nucos = require('../nucos');
 describe('nucos.sexagesimal2decimal', function(){
+    it('should fail with completely bad input', function(){
+        var lon = "random text";
+        assert.equal(nucos.sexagesimal2decimal(lon), 24.72504444);
+    });
+
+
     it('should convert lat long into decimal', function(){
         var lon = "24° 43' 30.16\"";
         var lat = "58° 44' 43.97\"";
@@ -106,44 +112,46 @@ describe('nucos.sexagesimal2decimal', function(){
 
         assert.equal(nucos.sexagesimal2decimal(lon), -24.72504444);
         assert.equal(nucos.sexagesimal2decimal(lat), -58.74554722);
+    // Additional tests from the Python version
+
     });
 
 
 
 });
 
-describe('nucos.convert', function(){
-    it('should convert same unit density', function(){
-        assert.equal(nucos.convert("Density", "API degree", "kg/m^3", 10), 999.13);
-    });
+// describe('nucos.convert', function(){
+//     it('should convert same unit density', function(){
+//         assert.equal(nucos.convert("Density", "API degree", "kg/m^3", 10), 999.13);
+//     });
 
-    it('should parse unicode exponents', function(){
-        assert.equal(nucos.convert('Density', 'API degree', 'kg/m³', 10), 999.13);
-    });
+//     it('should parse unicode exponents', function(){
+//         assert.equal(nucos.convert('Density', 'API degree', 'kg/m³', 10), 999.13);
+//     });
 
-    it('should convert Concentration', function(){
-        assert.equal(nucos.convert('Concentration', 'ppm', 'fraction', 1.0), 1e-6);
-    });
-
-    it('should convert Interfacial Tension', function(){
-        assert.equal(nucos.convert('InterfacialTension', 'N/m', 'dyn/cm', 1.0), 1e3);
-    });
-
-
-// describe('nocos.convert', function(){
 //     it('should convert Concentration', function(){
-//         assert.equal(nucos.Convert("Concentration", "ppm", "fraction", 1.0), 1e-6);
+//         assert.equal(nucos.convert('Concentration', 'ppm', 'fraction', 1.0), 1e-6);
+//     });
+
+//     it('should convert Interfacial Tension', function(){
+//         assert.equal(nucos.convert('InterfacialTension', 'N/m', 'dyn/cm', 1.0), 1e3);
 //     });
 
 
-});
-
-describe('nocos.OilQuantityConverter', function(){
-    it('should convert oil quantity between volume and mass', function(){
-        var oc = new nucos.OilQuantityConverter();
-        assert.equal(oc.Convert(50, "tons", 10, "API degree", "cubic meters"), 45.39873389849169);
-    });
+// // describe('nucos.convert', function(){
+// //     it('should convert Concentration', function(){
+// //         assert.equal(nucos.Convert("Concentration", "ppm", "fraction", 1.0), 1e-6);
+// //     });
 
 
-});
+// });
+
+// describe('nucos.OilQuantityConverter', function(){
+//     it('should convert oil quantity between volume and mass', function(){
+//         var oc = new nucos.OilQuantityConverter();
+//         assert.equal(oc.Convert(50, "tons", 10, "API degree", "cubic meters"), 45.39873389849169);
+//     });
+
+
+// });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -99,6 +99,17 @@ describe('nucos.sexagesimal2decimal', function(){
         assert.equal(nucos.sexagesimal2decimal(lon), 43.23423);
         assert.equal(nucos.sexagesimal2decimal(lat), -124.2334);
     });
+
+    it('should handle deg, min, sec with North and south', function(){
+        var lon = "24° 43' 30.16 West";
+        var lat = "58° 44' 43.97south";
+
+        assert.equal(nucos.sexagesimal2decimal(lon), -24.72504444);
+        assert.equal(nucos.sexagesimal2decimal(lat), -58.74554722);
+    });
+
+
+
 });
 
 describe('nucos.convert', function(){

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,11 +1,11 @@
 var assert = require('assert');
 
 describe('nucos', function(){
-    // it('should import with amd', function(){
-    //     var requirejs = require('requirejs');
-    //     var n_test = requirejs('/../nucos.js');
-    //     assert.notEqual(n_test, undefined);
-    // });
+    it('should import with amd', function(){
+        var requirejs = require('requirejs');
+        var n_test = requirejs('/../nucos.js');
+        assert.notEqual(n_test, undefined);
+    });
 
     it('should import with commonjs', function(){
         var n_test = require('../nucos');
@@ -14,12 +14,35 @@ describe('nucos', function(){
 });
 
 var nucos = require('../nucos');
+
 describe('nucos.sexagesimal2decimal', function(){
-    it('should fail with completely bad input', function(){
-        var lon = "random text";
-        assert.equal(nucos.sexagesimal2decimal(lon), 24.72504444);
+
+    // Bad input of various sorts
+    it('Should fail with bad input', function(){
+        assert.throws(() => nucos.sexagesimal2decimal("some_crap"));
     });
 
+    it('Should fail with empty string', function(){
+        assert.throws(() => nucos.sexagesimal2decimal(""));
+    });
+
+    // Bad input of various sorts
+    it('Should fail with multiple decimal points', function(){
+        assert.throws(() => nucos.sexagesimal2decimal("23.43.2"));
+    });
+
+    // Bad input of various sorts
+    it('Should fail with decimal in more than one field', function(){
+        assert.throws(() => nucos.sexagesimal2decimal("23.4 14.2"));
+    });
+
+    it('Should fail with too large values', function(){
+        assert.throws(() => nucos.sexagesimal2decimal("92 92"));
+    });
+
+    it('Should fail with too large values', function(){
+        assert.throws(() => nucos.sexagesimal2decimal("3° 25' 61.0\" N"));
+    });
 
     it('should convert lat long into decimal', function(){
         var lon = "24° 43' 30.16\"";
@@ -51,6 +74,46 @@ describe('nucos.sexagesimal2decimal', function(){
 
         assert.equal(nucos.sexagesimal2decimal(lon), -24.72504444);
         assert.equal(nucos.sexagesimal2decimal(lat), -58.74554722);
+    });
+
+    it('should convert to a negative w/ West and South', function(){
+        var lon = "24° 43' 30.16\"  West";
+        var lat = "58° 44' 43.97\"south";
+
+        assert.equal(nucos.sexagesimal2decimal(lon), -24.72504444);
+        assert.equal(nucos.sexagesimal2decimal(lat), -58.74554722);
+    });
+
+    it('should convert with a leading zero', function(){
+        var lon = "024° 43' 30.16\"w";
+        var lat = "058° 44' 43.97\"s";
+
+        assert.equal(nucos.sexagesimal2decimal(lon), -24.72504444);
+        assert.equal(nucos.sexagesimal2decimal(lat), -58.74554722);
+    });
+
+    it('should convert with space between - and number', function(){
+        var lon = "- 024° 43' 30.16\"w";
+        var lat = "  -  58.74554722  ";
+
+        assert.equal(nucos.sexagesimal2decimal(lon), -24.72504444);
+        assert.equal(nucos.sexagesimal2decimal(lat), -58.74554722);
+    });
+
+    it('should convert with minus as separator', function(){
+        var lon = "24-43-30.16\"w";
+        var lat = "-58 - 44 - 43.97";
+
+        assert.equal(nucos.sexagesimal2decimal(lon), -24.72504444);
+        assert.equal(nucos.sexagesimal2decimal(lat), -58.74554722);
+    });
+
+    it('should convert with verbose and letters', function(){
+        var lon = "15d 55m 20s south";
+        var lat = "15° 55′ 20\" north";
+
+        assert.equal(nucos.sexagesimal2decimal(lon), -15.92222222);
+        assert.equal(nucos.sexagesimal2decimal(lat), 15.92222222);
     });
 
     it('should convert to a negative w/ w and s', function(){
@@ -120,38 +183,38 @@ describe('nucos.sexagesimal2decimal', function(){
 
 });
 
+describe('nucos.convert', function(){
+    it('should convert same unit density', function(){
+        assert.equal(nucos.convert("Density", "API degree", "kg/m^3", 10), 999.13);
+    });
+
+    it('should parse unicode exponents', function(){
+        assert.equal(nucos.convert('Density', 'API degree', 'kg/m³', 10), 999.13);
+    });
+
+    it('should convert Concentration', function(){
+        assert.equal(nucos.convert('Concentration', 'ppm', 'fraction', 1.0), 1e-6);
+    });
+
+    it('should convert Interfacial Tension', function(){
+        assert.equal(nucos.convert('InterfacialTension', 'N/m', 'dyn/cm', 1.0), 1e3);
+    });
+
+
 // describe('nucos.convert', function(){
-//     it('should convert same unit density', function(){
-//         assert.equal(nucos.convert("Density", "API degree", "kg/m^3", 10), 999.13);
-//     });
-
-//     it('should parse unicode exponents', function(){
-//         assert.equal(nucos.convert('Density', 'API degree', 'kg/m³', 10), 999.13);
-//     });
-
 //     it('should convert Concentration', function(){
-//         assert.equal(nucos.convert('Concentration', 'ppm', 'fraction', 1.0), 1e-6);
-//     });
-
-//     it('should convert Interfacial Tension', function(){
-//         assert.equal(nucos.convert('InterfacialTension', 'N/m', 'dyn/cm', 1.0), 1e3);
+//         assert.equal(nucos.Convert("Concentration", "ppm", "fraction", 1.0), 1e-6);
 //     });
 
 
-// // describe('nucos.convert', function(){
-// //     it('should convert Concentration', function(){
-// //         assert.equal(nucos.Convert("Concentration", "ppm", "fraction", 1.0), 1e-6);
-// //     });
+});
+
+describe('nucos.OilQuantityConverter', function(){
+    it('should convert oil quantity between volume and mass', function(){
+        var oc = new nucos.OilQuantityConverter();
+        assert.equal(oc.Convert(50, "tons", 10, "API degree", "cubic meters"), 45.39873389849169);
+    });
 
 
-// });
-
-// describe('nucos.OilQuantityConverter', function(){
-//     it('should convert oil quantity between volume and mass', function(){
-//         var oc = new nucos.OilQuantityConverter();
-//         assert.equal(oc.Convert(50, "tons", 10, "API degree", "cubic meters"), 45.39873389849169);
-//     });
-
-
-// });
+});
 


### PR DESCRIPTION
The Lat-lon parser has been refactored -- it now matches the Python version, and can handle more input formats.

It also raises errors on more forms of bad input.

More tests should help if anyone wants to refactor again :-)

NOTE: I can't get the unit conversion tests to pass, but that's my setup, rather than any changes I made. See #12 for another PR that should get merged once we can get the testing to work.
